### PR TITLE
Rename `GenerateCrudAttribute` to `EntitySqlAttribute`

### DIFF
--- a/Entity2Sql.Attributes/EntitySqlAttribute.cs
+++ b/Entity2Sql.Attributes/EntitySqlAttribute.cs
@@ -1,0 +1,10 @@
+namespace Entity2Sql.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class EntitySqlAttribute : Attribute
+{
+  public EntitySqlAttribute(Type entity, string tableName)
+  {
+  }
+}
+

--- a/Entity2Sql.Attributes/GenerateCrudAttribute.cs
+++ b/Entity2Sql.Attributes/GenerateCrudAttribute.cs
@@ -1,9 +1,0 @@
-namespace Entity2Sql.Attributes;
-
-[AttributeUsage(AttributeTargets.Class)]
-public class GenerateCrudAttribute : Attribute
-{
-  public GenerateCrudAttribute()
-  {
-  }
-}

--- a/Entity2Sql.Attributes/GenerateCrudAttribute.cs
+++ b/Entity2Sql.Attributes/GenerateCrudAttribute.cs
@@ -3,7 +3,7 @@ namespace Entity2Sql.Attributes;
 [AttributeUsage(AttributeTargets.Class)]
 public class GenerateCrudAttribute : Attribute
 {
-  public GenerateCrudAttribute(Type generateFor, string tableName)
+  public GenerateCrudAttribute()
   {
   }
 }


### PR DESCRIPTION
- Rename `GenerateCrudAttribute` to `EntitySqlAttribute`
- Fix indentation for generated properties